### PR TITLE
docs: add Apify actor instructions

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -432,6 +432,32 @@ Minimum recommended specifications:
    - Disable unnecessary features
    - Regular security updates
 
+### Running on Apify
+
+The project can be deployed as an Apify actor. Provide input using the following fields:
+
+- `url` – starting URL to scrape or crawl
+- `options` – configuration object passed to the scraper
+- `max_concurrent` – maximum number of parallel pages
+
+Example input:
+
+```json
+{
+  "url": "https://example.com",
+  "options": {"formats": ["markdown"]},
+  "max_concurrent": 5
+}
+```
+
+Trigger runs from the Apify Console or via HTTP API:
+
+```bash
+curl -X POST "https://api.apify.com/v2/acts/<USERNAME>~<ACTOR-NAME>/run-sync?token=YOUR_APIFY_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"url":"https://example.com","options":{},"max_concurrent":5}'
+```
+
 ## Monitoring
 
 ### Prometheus Metrics

--- a/readme.md
+++ b/readme.md
@@ -202,6 +202,38 @@ environment:
   - CHROME_BIN=/usr/bin/google-chrome
 ```
 
+### Running on Apify
+
+eGet can run as an [Apify](https://apify.com) actor. The actor expects a JSON input with the following fields:
+
+- `url` *(string)* – starting page to scrape or crawl.
+- `options` *(object)* – scraper options passed to the underlying API (for example, output formats or wait settings).
+- `max_concurrent` *(integer)* – maximum number of parallel pages to process.
+
+Example input:
+
+```json
+{
+  "url": "https://example.com",
+  "options": {
+    "formats": ["markdown"],
+    "onlyMainContent": true
+  },
+  "max_concurrent": 5
+}
+```
+
+#### Triggering a run
+
+Runs can be started from the Apify Console by clicking **Run** on the actor and supplying the JSON input above.
+You can also trigger runs via the API:
+
+```bash
+curl -X POST "https://api.apify.com/v2/acts/<USERNAME>~<ACTOR-NAME>/run-sync?token=YOUR_APIFY_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"url":"https://example.com","options":{},"max_concurrent":5}'
+```
+
 ## 📝 API Usage Examples
 
 ### Single Page Scraping


### PR DESCRIPTION
## Summary
- document how to run eGet as an Apify actor
- detail required `url`, `options`, and `max_concurrent` fields
- show how to trigger runs from the console or via API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae28e09c448333b3ea410e7f0df3aa