### PR TITLE
feat: prioritize profile links over pagination

### DIFF
--- a/services/crawler/crawler_service.py
+++ b/services/crawler/crawler_service.py
@@ -59,14 +59,16 @@ class CrawlerService:
                 
                 # Extract new links if within depth limit
                 if depth < request.max_depth:
-                    new_links = link_extractor.extract_links(
+                    profile_links, pagination_links = link_extractor.extract_links(
                         scrape_result["data"]["html"],
                         url
                     )
-                    
+
                     async with self._lock:
-                        for link in new_links:
-                            await queue_manager.add_url(link, depth + 1, url)
+                        for link in profile_links:
+                            await queue_manager.add_url(link, depth + 1, url, priority=0)
+                        for link in pagination_links:
+                            await queue_manager.add_url(link, depth + 1, url, priority=1)
                 
                 # Store the page
                 async with self._lock:


### PR DESCRIPTION
## Summary
- prioritize profile links before pagination via priority queue
- classify pagination links and add to queue with lower priority
- process new profile links ahead of pagination for better crawl coverage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adfe2c89e48333845cc955b0df9995