### PR TITLE
Expose raw HTML alongside page text in crawler responses

### DIFF
--- a/api/v1/endpoints/crawler.py
+++ b/api/v1/endpoints/crawler.py
@@ -33,9 +33,10 @@ async def start_crawl(request: CrawlerRequest):
         # Transform to simplified format
         full_results = [
             {
-                "url": str(page.url),
-                "markdown": page.markdown,
-                "structured_data": page.structured_data  # Only include structured_data
+                "pageUrl": str(page.url),
+                "pageText": page.markdown,
+                "rawHTML": page.raw_html,
+                "structured_data": page.structured_data,
             }
             for page in results.pages
         ]

--- a/models/crawler_response.py
+++ b/models/crawler_response.py
@@ -15,6 +15,8 @@ class CrawledPage(BaseModel):
     """Model for individual crawled page data"""
     url: HttpUrl
     markdown: str
+    html: Optional[str] = None
+    raw_html: Optional[str] = None
     structured_data: Dict[str, Any]
     scrape_id: UUID
     crawled_at: datetime = Field(default_factory=datetime.utcnow)
@@ -59,6 +61,8 @@ class CrawlerResponse(BaseModel):
                     {
                         "url": "https://example.com",
                         "markdown": "# Example Page\nContent here...",
+                        "html": "<html>Example Page</html>",
+                        "raw_html": "<html>Example Page</html>",
                         "metadata": {
                             "title": "Example Page",
                             "description": "An example page",

--- a/services/crawler/crawler_service.py
+++ b/services/crawler/crawler_service.py
@@ -41,8 +41,8 @@ class CrawlerService:
             scrape_result = await self.scraper.scrape(
                 url,
                 {
-                    "only_main": True,
-                    "include_raw_html": False,
+                    "only_main": False,
+                    "include_raw_html": True,
                     "include_screenshot": False
                 }
             )
@@ -52,6 +52,8 @@ class CrawlerService:
                 page = CrawledPage(
                     url=url,
                     markdown=scrape_result["data"]["markdown"],
+                    html=scrape_result["data"].get("html"),
+                    raw_html=scrape_result["data"].get("rawHtml"),
                     structured_data=scrape_result["data"].get("structured_data"),
                     scrape_id=uuid.uuid4(),
                     depth=depth,


### PR DESCRIPTION
## Summary
- extend `CrawledPage` to store cleaned and raw HTML
- scrape with full HTML and include raw markup
- return pageUrl, pageText, and rawHTML in crawl endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adfe7b8d708333a9e1d720a8f41b69