### PR TITLE
feat: expose html fields in crawler output

### DIFF
--- a/api/v1/endpoints/crawler.py
+++ b/api/v1/endpoints/crawler.py
@@ -17,7 +17,7 @@ async def start_crawl(request: CrawlerRequest):
         request (CrawlerRequest): Crawl request parameters
         
     Returns:
-        List[Dict[str, str]]: List of crawled pages with URLs and markdown content
+        List[Dict[str, Any]]: List of crawled pages with URLs, text and HTML content
     """
     try:
         logger.info(f"Starting new crawl for URL: {request.url}")
@@ -30,12 +30,15 @@ async def start_crawl(request: CrawlerRequest):
                 detail=f"Crawl failed with status: {results.status}. Error: {results.error}"
             )
         
-        # Transform to simplified format
+        # Transform to simplified format including HTML and domain
         full_results = [
             {
                 "url": str(page.url),
+                "domain": page.domain,
                 "markdown": page.markdown,
-                "structured_data": page.structured_data  # Only include structured_data
+                "html": page.html,
+                "raw_html": page.raw_html,
+                "structured_data": page.structured_data,
             }
             for page in results.pages
         ]

--- a/models/crawler_response.py
+++ b/models/crawler_response.py
@@ -15,7 +15,10 @@ class CrawledPage(BaseModel):
     """Model for individual crawled page data"""
     url: HttpUrl
     markdown: str
+    html: Optional[str] = None
+    raw_html: Optional[str] = None
     structured_data: Dict[str, Any]
+    domain: Optional[str] = None
     scrape_id: UUID
     crawled_at: datetime = Field(default_factory=datetime.utcnow)
     depth: int = Field(ge=0)
@@ -57,16 +60,12 @@ class CrawlerResponse(BaseModel):
                 "status": "completed",
                 "pages": [
                     {
-                        "url": "https://example.com",
-                        "markdown": "# Example Page\nContent here...",
-                        "metadata": {
-                            "title": "Example Page",
-                            "description": "An example page",
-                            "language": "en",
-                            "sourceURL": "https://example.com",
-                            "url": "https://example.com",
-                            "statusCode": 200
-                        },
+                        "url": "https://example.com/about",
+                        "domain": "example.com",
+                        "markdown": "# About Us\nContent here...",
+                        "html": "<h1>About Us</h1><p>Content here...</p>",
+                        "raw_html": "<!doctype html><html>...</html>",
+                        "structured_data": {"title": "About Us"},
                         "scrape_id": "123e4567-e89b-12d3-a456-426614174001",
                         "depth": 0
                     }

--- a/services/crawler/crawler_service.py
+++ b/services/crawler/crawler_service.py
@@ -4,6 +4,7 @@ import uuid
 from datetime import datetime
 from loguru import logger
 from concurrent.futures import ThreadPoolExecutor
+from urllib.parse import urlparse
 
 from services.scraper.scraper import WebScraper
 from .link_extractor import LinkExtractor
@@ -42,7 +43,7 @@ class CrawlerService:
                 url,
                 {
                     "only_main": True,
-                    "include_raw_html": False,
+                    "include_raw_html": True,
                     "include_screenshot": False
                 }
             )
@@ -52,7 +53,10 @@ class CrawlerService:
                 page = CrawledPage(
                     url=url,
                     markdown=scrape_result["data"]["markdown"],
+                    html=scrape_result["data"].get("html"),
+                    raw_html=scrape_result["data"].get("rawHtml"),
                     structured_data=scrape_result["data"].get("structured_data"),
+                    domain=urlparse(url).netloc,
                     scrape_id=uuid.uuid4(),
                     depth=depth,
                 )


### PR DESCRIPTION
## Summary
- include html, raw_html and domain in crawler response schema
- return full page HTML fields from crawl endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adfeaa40f083339604dce3d9b77ae6