### PR TITLE
feat: allow wait-for-selector in crawler requests

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -159,7 +159,8 @@ Request Body:
     "\\/blog\\/.*",
     "\\/docs\\/.*"
   ],
-  "respect_robots_txt": true
+  "respect_robots_txt": true,
+  "wait_for_selector": ".main-content"
 }
 ```
 
@@ -366,7 +367,8 @@ def crawl_site():
         "include_patterns": [
             r"\/blog\/.*",
             r"\/docs\/.*"
-        ]
+        ],
+        "wait_for_selector": ".main-content"
     }
     
     response = requests.post(url, json=payload)

--- a/models/crawler_request.py
+++ b/models/crawler_request.py
@@ -14,6 +14,7 @@ class CrawlerRequest(BaseModel):
         exclude_patterns (List[str]): URL patterns to exclude from crawling
         include_patterns (List[str]): URL patterns to specifically include
         respect_robots_txt (bool): Whether to respect robots.txt rules
+        wait_for_selector (str, optional): CSS selector to wait for before scraping
         crawl_id (UUID): Unique identifier for the crawl request
     """
     url: HttpUrl
@@ -22,6 +23,7 @@ class CrawlerRequest(BaseModel):
     exclude_patterns: Optional[List[str]] = Field(default=[], description="URL patterns to exclude")
     include_patterns: Optional[List[str]] = Field(default=[], description="URL patterns to specifically include")
     respect_robots_txt: Optional[bool] = Field(default=True, description="Whether to respect robots.txt")
+    wait_for_selector: Optional[str] = Field(default=None, description="CSS selector to wait for before scraping")
     crawl_id: UUID = Field(default_factory=uuid4, description="Unique identifier for the crawl")
 
     @validator('exclude_patterns', 'include_patterns')
@@ -43,6 +45,7 @@ class CrawlerRequest(BaseModel):
                 "max_pages": 100,
                 "exclude_patterns": [r"\/api\/.*", r".*\.(jpg|jpeg|png|gif)$"],
                 "include_patterns": [r"\/blog\/.*", r"\/docs\/.*"],
-                "respect_robots_txt": True
+                "respect_robots_txt": True,
+                "wait_for_selector": ".main-content"
             }
         }

--- a/readme.md
+++ b/readme.md
@@ -277,7 +277,8 @@ def crawl_site_for_rag() -> List[Dict]:
             r"\/blog\/.*",  # Focus on blog content
             r"\/docs\/.*"   # And documentation
         ],
-        "respect_robots_txt": True
+        "respect_robots_txt": True,
+        "wait_for_selector": ".main-content"
     }
 
     response = requests.post(url, json=payload)

--- a/services/crawler/crawler_service.py
+++ b/services/crawler/crawler_service.py
@@ -43,7 +43,8 @@ class CrawlerService:
                 {
                     "only_main": True,
                     "include_raw_html": False,
-                    "include_screenshot": False
+                    "include_screenshot": False,
+                    "wait_for_selector": request.wait_for_selector
                 }
             )
             


### PR DESCRIPTION
## Summary
- allow crawler requests to specify a CSS selector to wait for
- pass selector to WebScraper so pages can wait on dynamic content
- document new `wait_for_selector` option in examples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adfeb66cdc8333b65e3959f5e6da19